### PR TITLE
security: externalize DEBUG/ALLOWED_HOSTS and add production hardening headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 venv
 *.pyc
+__pycache__/
 staticfiles
 .env
 db.*
+*.rdb

--- a/herokuwebinar/settings.py
+++ b/herokuwebinar/settings.py
@@ -21,11 +21,10 @@ PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-from os import environ
-SECRET_KEY = environ['SECRET_KEY']
+SECRET_KEY = os.environ['SECRET_KEY']
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DEBUG', 'False').lower() == 'true'
 
 # Application definition
 
@@ -50,7 +49,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-#     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -93,6 +91,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
     {
         'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'OPTIONS': {'min_length': 12},
     },
     {
         'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
@@ -118,8 +117,19 @@ DATABASES['default'].update(db_from_env)
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
-# Allow all host headers
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = [h.strip() for h in os.environ.get('ALLOWED_HOSTS', '').split(',') if h.strip()]
+
+# Production hardening — applied whenever DEBUG is off.
+if not DEBUG:
+    SECURE_SSL_REDIRECT = True
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SECURE_HSTS_SECONDS = 31536000
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    SECURE_REFERRER_POLICY = 'same-origin'
+    X_FRAME_OPTIONS = 'DENY'
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.10/howto/static-files/

--- a/herokuwebinar/wsgi.py
+++ b/herokuwebinar/wsgi.py
@@ -10,9 +10,7 @@ https://docs.djangoproject.com/en/1.10/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
-# from whitenoise.django import DjangoWhiteNoise
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "herokuwebinar.settings")
 
 application = get_wsgi_application()
-# application = DjangoWhiteNoise(application)


### PR DESCRIPTION
## Summary
- Read `DEBUG` from `os.environ` (defaults to `False`) instead of hardcoded `True`.
- Read `ALLOWED_HOSTS` from env (comma-separated) instead of the wildcard `['*']`.
- Add a `if not DEBUG:` block enabling `SECURE_SSL_REDIRECT`, `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, HSTS (1 year, subdomains, preload), `SECURE_CONTENT_TYPE_NOSNIFF`, `SECURE_REFERRER_POLICY`, and `X_FRAME_OPTIONS=DENY`.
- Tighten `MinimumLengthValidator` to `min_length: 12`.
- Drop dead commented-out middleware/`DjangoWhiteNoise` lines from `settings.py` and `wsgi.py`.
- Extend `.gitignore` with `*.rdb` and `__pycache__/`.

## Deployment note
`ALLOWED_HOSTS` now defaults to **empty** — set the `ALLOWED_HOSTS` Heroku config var (e.g. `your-app.herokuapp.com,yourdomain.com`) before deploying or every request will return HTTP 400.

## Test plan
- [ ] `python -m py_compile herokuwebinar/settings.py herokuwebinar/wsgi.py` succeeds (verified locally).
- [ ] Set `SECRET_KEY`, `ALLOWED_HOSTS`, and `DEBUG` env vars on Heroku before promoting.
- [ ] `python manage.py check --deploy` reports no security warnings in production env.
- [ ] Smoke-test a production request and confirm HSTS / `X-Frame-Options` headers are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)